### PR TITLE
feat: extend jwt/create token to get user name and id

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -6,6 +6,8 @@ to format the user profile data into json format.
 """
 
 from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth.password_validation import validate_password
 from authentication.models import User
 
@@ -62,3 +64,25 @@ class UserViewSerializer(serializers.ModelSerializer):
             "phone_no",
             "image",
         ]
+
+
+class CreateTokneSerialzer(TokenObtainPairSerializer):
+    """Create Token Serializer
+    This class is used to create the token. The token is created using the
+    TokenObtainPairSerializer class. The token is returned in a json format.
+    In this class the default error message is overridden. And also add some
+    additional information of user.
+    """
+
+    default_error_messages = {
+                        'no_active_account': _('Invalid username/password.')
+    }
+
+    def validate(self, attrs):
+        data = super().validate(attrs)
+        user = {}
+        user["id"] = self.user.id
+        user["first_name"] = self.user.first_name
+        user["last_name"] = self.user.last_name
+        data["user"] = user
+        return data

--- a/authentication/urls.py
+++ b/authentication/urls.py
@@ -7,10 +7,12 @@ tokens.
 """
 
 from django.urls import include, re_path
-
-# from django.conf.urls import url
+from rest_framework_simplejwt.views import (
+    TokenRefreshView,
+    TokenVerifyView,
+)
 from rest_framework import routers
-from authentication.views import UserViewSet
+from authentication.views import UserViewSet, CreateTokenView
 
 # pylint: disable=invalid-name
 app_name = "authentication"
@@ -21,7 +23,10 @@ router.register("user", UserViewSet, basename="user-view")
 
 urlpatterns = [
     re_path("", include("djoser.urls")),
-    re_path("", include("djoser.urls.jwt")),
+    re_path("jwt/create/", CreateTokenView.as_view(), name="create-token"),
+    re_path("jwt/refresh/", TokenRefreshView.as_view(), name="refresh-token"),
+    re_path("jwt/verify/", TokenVerifyView.as_view(), name="verify-token"),
+
 ]
 
 urlpatterns += router.urls

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -18,8 +18,9 @@ from rest_framework.mixins import (
     UpdateModelMixin,
 )
 from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.views import TokenViewBase
 from authentication.serializers import (
-    UserRegisterSerializer, UserViewSerializer
+    UserRegisterSerializer, UserViewSerializer, CreateTokneSerialzer
 )
 from authentication.permissions import OwnProfilePermission
 from authentication.models import User
@@ -58,3 +59,14 @@ class UserViewSet(
         if self.action == "create":
             return UserRegisterSerializer
         return self.serializer_class
+
+
+class CreateTokenView(TokenViewBase):
+    """Create Token View
+
+    This view is used to create a new token. This is inherited from the
+    TokenViewBase of the rest_framework_simplejwt.views. The purpose of this
+    view is to create a new token and override the default_error_message.
+    """
+
+    serializer_class = CreateTokneSerialzer

--- a/blogs_drf/urls.py
+++ b/blogs_drf/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path, re_path
+from django.urls import path, re_path, include
 
 
 from drf_yasg.views import get_schema_view
@@ -29,6 +29,8 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('auth/', include('authentication.urls')),
+
     re_path(
             r'^swagger(?P<format>\.json|\.yaml)$',
             schema_view.without_ui(cache_timeout=0),


### PR DESCRIPTION
#### Exted Creation of JWT Token

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR extend the creation of `JWT Token`. We are returning some additional user information with `JWT Token`.
In addition, we have overridden the default error message of an invalid user.

#### How should this be manually tested?
This can be tested by hitting the API http://127.0.0.1:8000/auth/jwt/create/ with `email` and `password`.

#### Any background context you want to provide?
None

#### Screenshots (if appropriate)
None